### PR TITLE
feat: implement invite link system with multi-user support

### DIFF
--- a/src/main/java/com/timetrak/controller/AuthController.java
+++ b/src/main/java/com/timetrak/controller/AuthController.java
@@ -1,6 +1,5 @@
 package com.timetrak.controller;
 
-import com.timetrak.dto.request.EmployeeRequestDTO;
 import com.timetrak.security.auth.JwtService;
 import com.timetrak.security.auth.dto.AuthRequest;
 import com.timetrak.security.auth.dto.AuthResponse;
@@ -12,7 +11,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -47,26 +45,6 @@ public class AuthController {
     }
 
 
-    @Operation(summary = "Register new employee", description = "Register a new employee account")
-    @PostMapping("/register")
-    public ResponseEntity<AuthResponse> register(@Valid @RequestBody EmployeeRequestDTO request,
-                                                 HttpServletResponse response) {
-        log.info("Registration attempt for username: {}", request.getUsername());
-        AuthResponse authResponse = authService.register(request);
-
-        Cookie refreshCookie = new Cookie("refreshToken", authResponse.getRefreshToken());
-        log.debug(authResponse.getRefreshToken());
-        refreshCookie.setHttpOnly(true);
-        refreshCookie.setSecure(true);
-        refreshCookie.setAttribute("SameSite", "Strict");
-        refreshCookie.setPath("/");
-        refreshCookie.setMaxAge(7 * 24 * 60 * 60); // 7 days
-        response.addCookie(refreshCookie);
-
-        //no refresh token in response body
-        authResponse.setRefreshToken(null);
-        return ResponseEntity.status(HttpStatus.CREATED).body(authResponse);
-    }
 
 
     @PostMapping("/login")

--- a/src/main/java/com/timetrak/controller/admin/AdminInviteController.java
+++ b/src/main/java/com/timetrak/controller/admin/AdminInviteController.java
@@ -1,0 +1,94 @@
+package com.timetrak.controller.admin;
+
+import com.timetrak.dto.invite.InviteCreateRequestDTO;
+import com.timetrak.dto.invite.InviteResponseDTO;
+import com.timetrak.service.auth.AuthContextService;
+import com.timetrak.service.invite.InviteService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin/invites")
+@RequiredArgsConstructor
+@Slf4j
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminInviteController {
+
+    private final InviteService inviteService;
+    private final AuthContextService authContextService;
+
+    @PostMapping
+    public ResponseEntity<InviteResponseDTO> createInvite(@Valid @RequestBody InviteCreateRequestDTO request) {
+        Long currentEmployeeId = authContextService.getCurrentEmployeeId();
+        Long currentCompanyId = authContextService.getCurrentCompanyId();
+        
+        // Ensure the request is for the current user's company
+        request.setCompanyId(currentCompanyId);
+        
+        InviteResponseDTO response = inviteService.createInvite(request, currentEmployeeId);
+        
+        log.info("Invite created with code: {} by employee: {}", response.getInviteCode(), currentEmployeeId);
+        
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/{inviteCode}")
+    public ResponseEntity<InviteResponseDTO> getInviteByCode(@PathVariable String inviteCode) {
+        Long currentCompanyId = authContextService.getCurrentCompanyId();
+        InviteResponseDTO response = inviteService.getInviteByCode(inviteCode);
+        
+        // Ensure the invite belongs to the current user's company
+        if (!response.getCompanyId().equals(currentCompanyId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+        
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<InviteResponseDTO>> getInvites(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "createdAt") String sortBy,
+            @RequestParam(defaultValue = "desc") String sortDir) {
+        
+        Long currentCompanyId = authContextService.getCurrentCompanyId();
+        
+        Sort.Direction direction = sortDir.equalsIgnoreCase("desc") 
+            ? Sort.Direction.DESC 
+            : Sort.Direction.ASC;
+        
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortBy));
+        Page<InviteResponseDTO> response = inviteService.getInvitesByCompany(currentCompanyId, pageable);
+        
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/active")
+    public ResponseEntity<List<InviteResponseDTO>> getActiveInvites() {
+        Long currentCompanyId = authContextService.getCurrentCompanyId();
+        List<InviteResponseDTO> response = inviteService.getActiveInvitesByCompany(currentCompanyId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{inviteCode}/deactivate")
+    public ResponseEntity<InviteResponseDTO> deactivateInvite(@PathVariable String inviteCode) {
+        Long currentCompanyId = authContextService.getCurrentCompanyId();
+        InviteResponseDTO response = inviteService.deactivateInvite(inviteCode, currentCompanyId);
+        
+        log.info("Invite deactivated: {} by company: {}", inviteCode, currentCompanyId);
+        
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/timetrak/controller/user/UserInviteController.java
+++ b/src/main/java/com/timetrak/controller/user/UserInviteController.java
@@ -1,0 +1,42 @@
+package com.timetrak.controller.user;
+
+import com.timetrak.dto.invite.InviteSignupRequestDTO;
+import com.timetrak.dto.invite.InviteValidationResponseDTO;
+import com.timetrak.dto.response.EmployeeResponseDTO;
+import com.timetrak.service.invite.InviteService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/user/invites")
+@RequiredArgsConstructor
+@Slf4j
+public class UserInviteController {
+
+    private final InviteService inviteService;
+
+    @GetMapping("/validate/{inviteCode}")
+    public ResponseEntity<InviteValidationResponseDTO> validateInvite(@PathVariable String inviteCode) {
+        InviteValidationResponseDTO response = inviteService.validateInvite(inviteCode);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<EmployeeResponseDTO> registerWithInvite(@Valid @RequestBody InviteSignupRequestDTO request) {
+        EmployeeResponseDTO response = inviteService.registerEmployeeWithInvite(request);
+        
+        log.info("Employee registered with invite code: {}", request.getInviteCode());
+        
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/url/{inviteCode}")
+    public ResponseEntity<String> getInviteUrl(@PathVariable String inviteCode) {
+        String inviteUrl = inviteService.generateInviteUrl(inviteCode);
+        return ResponseEntity.ok(inviteUrl);
+    }
+}

--- a/src/main/java/com/timetrak/dto/invite/InviteCreateRequestDTO.java
+++ b/src/main/java/com/timetrak/dto/invite/InviteCreateRequestDTO.java
@@ -1,0 +1,30 @@
+package com.timetrak.dto.invite;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InviteCreateRequestDTO {
+
+    @NotNull(message = "Company ID is required")
+    private Long companyId;
+
+    private Long departmentId;
+
+    @NotNull(message = "Max uses is required")
+    @Min(value = 1, message = "Max uses must be at least 1")
+    private Integer maxUses;
+
+    @NotNull(message = "Expiry hours is required")
+    @Min(value = 1, message = "Expiry hours must be at least 1")
+    private Integer expiryHours;
+
+    private String description;
+}

--- a/src/main/java/com/timetrak/dto/invite/InviteResponseDTO.java
+++ b/src/main/java/com/timetrak/dto/invite/InviteResponseDTO.java
@@ -1,0 +1,30 @@
+package com.timetrak.dto.invite;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InviteResponseDTO {
+
+    private Long id;
+    private String inviteCode;
+    private String inviteUrl;
+    private Long companyId;
+    private Long departmentId;
+    private Integer maxUses;
+    private Integer currentUses;
+    private Boolean isActive;
+    private LocalDateTime expiresAt;
+    private LocalDateTime createdAt;
+    private String description;
+    private Boolean isExpired;
+    private Boolean isFullyUsed;
+    private Boolean isValid;
+}

--- a/src/main/java/com/timetrak/dto/invite/InviteSignupRequestDTO.java
+++ b/src/main/java/com/timetrak/dto/invite/InviteSignupRequestDTO.java
@@ -1,0 +1,41 @@
+package com.timetrak.dto.invite;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InviteSignupRequestDTO {
+
+    @NotBlank(message = "Invite code is required")
+    private String inviteCode;
+
+    @NotBlank(message = "First name is required")
+    @Size(max = 50, message = "First name must not exceed 50 characters")
+    private String firstName;
+
+    @NotBlank(message = "Last name is required")
+    @Size(max = 50, message = "Last name must not exceed 50 characters")
+    private String lastName;
+
+    @Email(message = "Email should be valid")
+    @NotBlank(message = "Email is required")
+    private String email;
+
+    @NotBlank(message = "Username is required")
+    @Size(min = 3, max = 30, message = "Username must be between 3 and 30 characters")
+    @Pattern(regexp = "^[a-zA-Z0-9._-]+$",
+            message = "Username can only contain letters, numbers, dots, underscores, and hyphens")
+    private String username;
+
+    @NotBlank(message = "Password is required")
+    @Size(min = 8, message = "Password must be at least 8 characters long")
+    private String password;
+
+    private String phoneNumber;
+}

--- a/src/main/java/com/timetrak/dto/invite/InviteValidationResponseDTO.java
+++ b/src/main/java/com/timetrak/dto/invite/InviteValidationResponseDTO.java
@@ -1,0 +1,20 @@
+package com.timetrak.dto.invite;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InviteValidationResponseDTO {
+
+    private Boolean isValid;
+    private String message;
+    private Long companyId;
+    private Long departmentId;
+    private String companyName;
+    private String departmentName;
+}

--- a/src/main/java/com/timetrak/entity/EmployeeInvite.java
+++ b/src/main/java/com/timetrak/entity/EmployeeInvite.java
@@ -1,0 +1,69 @@
+package com.timetrak.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "employee_invites")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class EmployeeInvite extends BaseEntity {
+
+    @Column(name = "invite_code", nullable = false, unique = true)
+    private String inviteCode;
+
+    @Column(name = "company_id", nullable = false)
+    private Long companyId;
+
+    @Column(name = "department_id")
+    private Long departmentId;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "max_uses", nullable = false)
+    private Integer maxUses = 1;
+
+    @Column(name = "current_uses", nullable = false)
+    private Integer currentUses = 0;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive = true;
+
+    @Column(name = "created_by_employee_id", nullable = false)
+    private Long createdByEmployeeId;
+
+    @Column(name = "description")
+    private String description;
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+
+    public boolean isFullyUsed() {
+        return currentUses >= maxUses;
+    }
+
+    public boolean isValid() {
+        return isActive && !isExpired() && !isFullyUsed();
+    }
+
+    public boolean canBeUsed() {
+        return isValid() && currentUses < maxUses;
+    }
+
+    public void incrementUse() {
+        if (canBeUsed()) {
+            this.currentUses++;
+        }
+    }
+}

--- a/src/main/java/com/timetrak/repository/EmployeeInviteRepository.java
+++ b/src/main/java/com/timetrak/repository/EmployeeInviteRepository.java
@@ -1,0 +1,35 @@
+package com.timetrak.repository;
+
+import com.timetrak.entity.EmployeeInvite;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface EmployeeInviteRepository extends JpaRepository<EmployeeInvite, Long> {
+
+    Optional<EmployeeInvite> findByInviteCode(String inviteCode);
+
+    @Query("SELECT ei FROM EmployeeInvite ei WHERE ei.inviteCode = :inviteCode AND ei.isActive = true")
+    Optional<EmployeeInvite> findActiveInviteByCode(@Param("inviteCode") String inviteCode);
+
+    List<EmployeeInvite> findByCompanyIdAndIsActiveTrue(Long companyId);
+
+    List<EmployeeInvite> findByCompanyIdAndCreatedByEmployeeId(Long companyId, Long createdByEmployeeId);
+
+    @Query("SELECT ei FROM EmployeeInvite ei WHERE ei.expiresAt < :now AND ei.isActive = true")
+    List<EmployeeInvite> findExpiredInvites(@Param("now") LocalDateTime now);
+
+    boolean existsByInviteCode(String inviteCode);
+
+    @Query("SELECT ei FROM EmployeeInvite ei WHERE ei.companyId = :companyId AND ei.departmentId = :departmentId AND ei.isActive = true")
+    List<EmployeeInvite> findActiveInvitesByCompanyAndDepartment(@Param("companyId") Long companyId, @Param("departmentId") Long departmentId);
+
+    @Query("SELECT COUNT(ei) FROM EmployeeInvite ei WHERE ei.companyId = :companyId AND ei.isActive = true")
+    long countActiveInvitesByCompany(@Param("companyId") Long companyId);
+}

--- a/src/main/java/com/timetrak/security/SecurityConfig.java
+++ b/src/main/java/com/timetrak/security/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/companies/register").permitAll()
 
                         .requestMatchers("/api/auth/login", "/api/auth/refresh", "/api/auth/register").permitAll()
+                        .requestMatchers("/api/user/invites/**").permitAll()
 
                         // Kiosk routes (for employee self-service clock in/out)
                         .requestMatchers("/api/kiosk/**").permitAll()

--- a/src/main/java/com/timetrak/service/auth/AuthService.java
+++ b/src/main/java/com/timetrak/service/auth/AuthService.java
@@ -1,12 +1,10 @@
 package com.timetrak.service.auth;
 
-import com.timetrak.dto.request.EmployeeRequestDTO;
 import com.timetrak.security.auth.dto.AuthRequest;
 import com.timetrak.security.auth.dto.AuthResponse;
 
 public interface AuthService {
     AuthResponse login(AuthRequest request);
-    AuthResponse register(EmployeeRequestDTO request);
     void logout(String token);
     AuthResponse refreshToken(String refreshToken);
     void changePassword(String username, String oldPassword, String newPassword);

--- a/src/main/java/com/timetrak/service/invite/InviteService.java
+++ b/src/main/java/com/timetrak/service/invite/InviteService.java
@@ -1,0 +1,32 @@
+package com.timetrak.service.invite;
+
+import com.timetrak.dto.invite.InviteCreateRequestDTO;
+import com.timetrak.dto.invite.InviteResponseDTO;
+import com.timetrak.dto.invite.InviteSignupRequestDTO;
+import com.timetrak.dto.invite.InviteValidationResponseDTO;
+import com.timetrak.dto.response.EmployeeResponseDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface InviteService {
+
+    InviteResponseDTO createInvite(InviteCreateRequestDTO request, Long createdByEmployeeId);
+
+    InviteValidationResponseDTO validateInvite(String inviteCode);
+
+    EmployeeResponseDTO registerEmployeeWithInvite(InviteSignupRequestDTO request);
+
+    InviteResponseDTO getInviteByCode(String inviteCode);
+
+    Page<InviteResponseDTO> getInvitesByCompany(Long companyId, Pageable pageable);
+
+    List<InviteResponseDTO> getActiveInvitesByCompany(Long companyId);
+
+    InviteResponseDTO deactivateInvite(String inviteCode, Long companyId);
+
+    void cleanupExpiredInvites();
+
+    String generateInviteUrl(String inviteCode);
+}

--- a/src/main/java/com/timetrak/service/invite/InviteServiceImpl.java
+++ b/src/main/java/com/timetrak/service/invite/InviteServiceImpl.java
@@ -1,0 +1,237 @@
+package com.timetrak.service.invite;
+
+import com.timetrak.dto.invite.InviteCreateRequestDTO;
+import com.timetrak.dto.invite.InviteResponseDTO;
+import com.timetrak.dto.invite.InviteSignupRequestDTO;
+import com.timetrak.dto.invite.InviteValidationResponseDTO;
+import com.timetrak.dto.request.EmployeeRequestDTO;
+import com.timetrak.dto.response.EmployeeResponseDTO;
+import com.timetrak.entity.Company;
+import com.timetrak.entity.Department;
+import com.timetrak.entity.EmployeeInvite;
+import com.timetrak.exception.ResourceNotFoundException;
+import com.timetrak.repository.CompanyRepository;
+import com.timetrak.repository.DepartmentRepository;
+import com.timetrak.repository.EmployeeInviteRepository;
+import com.timetrak.service.employee.EmployeeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class InviteServiceImpl implements InviteService {
+
+    private final EmployeeInviteRepository inviteRepository;
+    private final CompanyRepository companyRepository;
+    private final DepartmentRepository departmentRepository;
+    private final EmployeeService employeeService;
+
+    @Value("${app.frontend.url:http://localhost:3000}")
+    private String frontendUrl;
+
+    @Override
+    public InviteResponseDTO createInvite(InviteCreateRequestDTO request, Long createdByEmployeeId) {
+        Company company = companyRepository.findById(request.getCompanyId())
+                .orElseThrow(() -> new ResourceNotFoundException("Company not found"));
+
+        Department department = null;
+        if (request.getDepartmentId() != null) {
+            department = departmentRepository.findById(request.getDepartmentId())
+                    .orElseThrow(() -> new ResourceNotFoundException("Department not found"));
+            
+            if (!department.getCompany().getId().equals(request.getCompanyId())) {
+                throw new IllegalArgumentException("Department does not belong to the specified company");
+            }
+        }
+
+        String inviteCode;
+        do {
+            inviteCode = UUID.randomUUID().toString().replace("-", "").substring(0, 16).toUpperCase();
+        } while (inviteRepository.existsByInviteCode(inviteCode));
+
+        LocalDateTime expiresAt = LocalDateTime.now().plusHours(request.getExpiryHours());
+
+        EmployeeInvite invite = EmployeeInvite.builder()
+                .inviteCode(inviteCode)
+                .companyId(request.getCompanyId())
+                .departmentId(request.getDepartmentId())
+                .maxUses(request.getMaxUses())
+                .currentUses(0)
+                .expiresAt(expiresAt)
+                .isActive(true)
+                .createdByEmployeeId(createdByEmployeeId)
+                .description(request.getDescription())
+                .build();
+
+        invite = inviteRepository.save(invite);
+
+        log.info("Created invite with code: {} for company: {} by employee: {}", 
+                inviteCode, request.getCompanyId(), createdByEmployeeId);
+
+        return mapToResponseDTO(invite);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public InviteValidationResponseDTO validateInvite(String inviteCode) {
+        EmployeeInvite invite = inviteRepository.findActiveInviteByCode(inviteCode)
+                .orElse(null);
+
+        if (invite == null || !invite.isValid()) {
+            return InviteValidationResponseDTO.builder()
+                    .isValid(false)
+                    .message("Invalid or expired invite code")
+                    .build();
+        }
+
+        Company company = companyRepository.findById(invite.getCompanyId())
+                .orElseThrow(() -> new ResourceNotFoundException("Company not found"));
+
+        Department department = null;
+        if (invite.getDepartmentId() != null) {
+            department = departmentRepository.findById(invite.getDepartmentId()).orElse(null);
+        }
+
+        return InviteValidationResponseDTO.builder()
+                .isValid(true)
+                .message("Invite is valid")
+                .companyId(invite.getCompanyId())
+                .departmentId(invite.getDepartmentId())
+                .companyName(company.getName())
+                .departmentName(department != null ? department.getName() : null)
+                .build();
+    }
+
+    @Override
+    public EmployeeResponseDTO registerEmployeeWithInvite(InviteSignupRequestDTO request) {
+        EmployeeInvite invite = inviteRepository.findActiveInviteByCode(request.getInviteCode())
+                .orElseThrow(() -> new IllegalArgumentException("Invalid invite code"));
+
+        if (!invite.isValid()) {
+            throw new IllegalArgumentException("Invite code is expired or fully used");
+        }
+
+        // Create employee request DTO
+        EmployeeRequestDTO employeeRequest = EmployeeRequestDTO.builder()
+                .firstName(request.getFirstName())
+                .lastName(request.getLastName())
+                .email(request.getEmail())
+                .password(request.getPassword())
+                .phoneNumber(request.getPhoneNumber())
+                .username(request.getUsername())
+                .companyId(invite.getCompanyId())
+                .departmentId(invite.getDepartmentId())
+                .build();
+
+        // Create the employee
+        EmployeeResponseDTO employee = employeeService.createEmployee(employeeRequest);
+
+        // Increment invite usage
+        invite.incrementUse();
+        inviteRepository.save(invite);
+
+        log.info("Employee registered with invite code: {} for company: {}", 
+                request.getInviteCode(), invite.getCompanyId());
+
+        return employee;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public InviteResponseDTO getInviteByCode(String inviteCode) {
+        EmployeeInvite invite = inviteRepository.findByInviteCode(inviteCode)
+                .orElseThrow(() -> new ResourceNotFoundException("Invite not found"));
+
+        return mapToResponseDTO(invite);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<InviteResponseDTO> getInvitesByCompany(Long companyId, Pageable pageable) {
+        Page<EmployeeInvite> invites = inviteRepository.findAll(pageable);
+        List<InviteResponseDTO> responseDTOs = invites.getContent().stream()
+                .filter(invite -> invite.getCompanyId().equals(companyId))
+                .map(this::mapToResponseDTO)
+                .collect(Collectors.toList());
+
+        return new PageImpl<>(responseDTOs, pageable, responseDTOs.size());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<InviteResponseDTO> getActiveInvitesByCompany(Long companyId) {
+        List<EmployeeInvite> invites = inviteRepository.findByCompanyIdAndIsActiveTrue(companyId);
+        return invites.stream()
+                .map(this::mapToResponseDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public InviteResponseDTO deactivateInvite(String inviteCode, Long companyId) {
+        EmployeeInvite invite = inviteRepository.findByInviteCode(inviteCode)
+                .orElseThrow(() -> new ResourceNotFoundException("Invite not found"));
+
+        if (!invite.getCompanyId().equals(companyId)) {
+            throw new IllegalArgumentException("Invite does not belong to the specified company");
+        }
+
+        invite.setIsActive(false);
+        invite = inviteRepository.save(invite);
+
+        log.info("Deactivated invite with code: {} for company: {}", inviteCode, companyId);
+
+        return mapToResponseDTO(invite);
+    }
+
+    @Override
+    @Scheduled(fixedRate = 3600000) // Run every hour
+    public void cleanupExpiredInvites() {
+        List<EmployeeInvite> expiredInvites = inviteRepository.findExpiredInvites(LocalDateTime.now());
+        for (EmployeeInvite invite : expiredInvites) {
+            invite.setIsActive(false);
+        }
+        inviteRepository.saveAll(expiredInvites);
+        
+        if (!expiredInvites.isEmpty()) {
+            log.info("Cleaned up {} expired invites", expiredInvites.size());
+        }
+    }
+
+    @Override
+    public String generateInviteUrl(String inviteCode) {
+        return frontendUrl + "/register?invite=" + inviteCode;
+    }
+
+    private InviteResponseDTO mapToResponseDTO(EmployeeInvite invite) {
+        return InviteResponseDTO.builder()
+                .id(invite.getId())
+                .inviteCode(invite.getInviteCode())
+                .inviteUrl(generateInviteUrl(invite.getInviteCode()))
+                .companyId(invite.getCompanyId())
+                .departmentId(invite.getDepartmentId())
+                .maxUses(invite.getMaxUses())
+                .currentUses(invite.getCurrentUses())
+                .isActive(invite.getIsActive())
+                .expiresAt(invite.getExpiresAt())
+                .createdAt(invite.getCreatedAt())
+                .description(invite.getDescription())
+                .isExpired(invite.isExpired())
+                .isFullyUsed(invite.isFullyUsed())
+                .isValid(invite.isValid())
+                .build();
+    }
+}


### PR DESCRIPTION
- Add EmployeeInvite entity with usage tracking
- Create admin endpoints for invite management (/api/admin/invites)
- Add public registration endpoint (/api/user/invites/register)
- Support bulk onboarding (30+ employees per invite)
- Include company/department assignment via invite codes